### PR TITLE
fixing a bug when yPos_ have continuous zero value region

### DIFF
--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -290,7 +290,11 @@ public:
             }else{
                 shift = yPos_[i+1]-yPos_[i];
                 auto yEnd = yPos_[i]*(1.0 - alpha) + yPos_[i+1]*alpha;
-                shift = shift*y/yEnd;
+                if (yEnd > 0.) {
+                    shift = shift*y/yEnd;
+                } else {
+                    shift = 0.;
+                }
             }
         }    
         auto ylower =  y-alpha*shift;


### PR DESCRIPTION
in UniformXTabulated2DFunction